### PR TITLE
refactor: rubocopのStyle/StringLiteralsルールを修正。シングルコーテーションに統一。

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -48,8 +48,8 @@ class GroupsController < ApplicationController
       format.turbo_stream do
         # calculation-results 部分だけを更新
         render turbo_stream: turbo_stream.replace(
-          "calculation-results",
-          partial: "groups/calculation_results",
+          'calculation-results',
+          partial: 'groups/calculation_results',
           locals: {
             per_person_amount: @per_person_amount,
             grouped_amounts: @grouped_amounts,

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -46,12 +46,12 @@ class ParticipantsController < ApplicationController
         format.turbo_stream do
           render turbo_stream: turbo_stream.replace(
             dom_id(@participant),
-            partial: "participants/participant",
+            partial: 'participants/participant',
             locals: { participant: @participant, per_person_amount: @per_person_amount }
           ) +
           turbo_stream.update(
-            "calculation-results",
-            partial: "groups/calculation_results",
+            'calculation-results',
+            partial: 'groups/calculation_results',
             locals: {
               per_person_amount: @per_person_amount,
               grouped_amounts: @grouped_amounts,

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
-  layout "mailer"
+  default from: 'from@example.com'
+  layout 'mailer'
 end

--- a/spec/controllers/concerns/bill_spliter_spec.rb
+++ b/spec/controllers/concerns/bill_spliter_spec.rb
@@ -6,27 +6,27 @@ RSpec.describe BillSplitter do
   end
 
   # .remove_remainderメソッドのテスト
-  describe ".remove_remainde" do
-    it "支払い金額と有効桁数が与えられたとき、有効桁数に変換された金額が正しく計算されるか" do
+  describe '.remove_remainde' do
+    it '支払い金額と有効桁数が与えられたとき、有効桁数に変換された金額が正しく計算されるか' do
       total_amount = 33333
       rounding_rule = 10
       expect(BillSplitter.send(:remove_remainder, total_amount, rounding_rule)).to eq 33330
     end
-    it "支払い金額のみ与えられたとき、デフォルト値で有効桁数に変換された金額が正しく計算されるか" do
+    it '支払い金額のみ与えられたとき、デフォルト値で有効桁数に変換された金額が正しく計算されるか' do
       total_amount = 33333
       expect(BillSplitter.send(:remove_remainder, total_amount)).to eq 33300
     end
   end
 
   # .calculate_unfixed_split_amountメソッドのテスト
-  describe ".calculate_unfixed_split_amount" do
-    it "" do
+  describe '.calculate_unfixed_split_amount' do
+    it '' do
     end
   end
 
   # .calculate_remainderメソッドのテスト
-  describe ".calculate_remainder" do
-    it "" do
+  describe '.calculate_remainder' do
+    it '' do
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 # Uncomment the line below in case you have `--require rails_helper` in the `.rspec` file
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
-RSpec.describe "Groups", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/groups/index"
+RSpec.describe 'Groups', type: :request do
+  describe 'GET /index' do
+    it 'returns http success' do
+      get '/groups/index'
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /create" do
-    it "returns http success" do
-      get "/groups/create"
+  describe 'GET /create' do
+    it 'returns http success' do
+      get '/groups/create'
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /destroy" do
-    it "returns http success" do
-      get "/groups/destroy"
+  describe 'GET /destroy' do
+    it 'returns http success' do
+      get '/groups/destroy'
       expect(response).to have_http_status(:success)
     end
   end
@@ -26,44 +26,44 @@ RSpec.describe "Groups", type: :request do
   let(:valid_attributes) {
     {
       group: {
-        name: "2025 new year party",
-        participant_count: "5"
+        name: '2025 new year party',
+        participant_count: '5'
       }
     }
   }
   let(:invalid_attributes) {
     {
       group: {
-        name: "2026 new year party",
-        participant_count: "5",
-        malicious_param: "invalid_atr"
+        name: '2026 new year party',
+        participant_count: '5',
+        malicious_param: 'invalid_atr'
       }
     }
   }
-  describe "POST #create" do
-    context "グループ作成時許可されたパラメータの場合" do
-      it "モデルが作成されること" do
+  describe 'POST #create' do
+    context 'グループ作成時許可されたパラメータの場合' do
+      it 'モデルが作成されること' do
         expect {
           post groups_path, params: valid_attributes
         }.to change(Group, :count).by(1)
       end
-      it "正しい属性でモデルが作成されること" do
+      it '正しい属性でモデルが作成されること' do
         post groups_path, params: valid_attributes
-        expect(Group.last.name).to eq("2025 new year party")
+        expect(Group.last.name).to eq('2025 new year party')
       end
     end
 
-    context "グループ作成時許可されていないパラメータが含まれる場合" do
-      it "悪意のあるパラメータが保存されないこと" do
+    context 'グループ作成時許可されていないパラメータが含まれる場合' do
+      it '悪意のあるパラメータが保存されないこと' do
         post groups_path, params: invalid_attributes
         expect(Group.last).not_to respond_to(:malicious_param)
-        expect(Group.last.attributes.keys).not_to include("malicious_param")
+        expect(Group.last.attributes.keys).not_to include('malicious_param')
       end
-      it "モデルが作成されるが、悪意のあるパラメータは無視されること" do
+      it 'モデルが作成されるが、悪意のあるパラメータは無視されること' do
         expect {
           post groups_path, params: invalid_attributes
         }.to change(Group, :count).by(1)
-        expect(Group.last.name).to eq("2026 new year party")
+        expect(Group.last.name).to eq('2026 new year party')
       end
     end
   end

--- a/spec/requests/participants_spec.rb
+++ b/spec/requests/participants_spec.rb
@@ -1,30 +1,30 @@
 require 'rails_helper'
 
-RSpec.describe "Participants", type: :request do
-  describe "GET /create" do
-    it "returns http success" do
-      get "/participants/create"
+RSpec.describe 'Participants', type: :request do
+  describe 'GET /create' do
+    it 'returns http success' do
+      get '/participants/create'
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /destroy" do
-    it "returns http success" do
-      get "/participants/destroy"
+  describe 'GET /destroy' do
+    it 'returns http success' do
+      get '/participants/destroy'
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /update" do
-    it "returns http success" do
-      get "/participants/update"
+  describe 'GET /update' do
+    it 'returns http success' do
+      get '/participants/update'
       expect(response).to have_http_status(:success)
     end
   end
 
-  describe "GET /show" do
-    it "returns http success" do
-      get "/participants/show"
+  describe 'GET /show' do
+    it 'returns http success' do
+      get '/participants/show'
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/views/groups/create.html.tailwindcss_spec.rb
+++ b/spec/views/groups/create.html.tailwindcss_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "groups/create.html.tailwindcss", type: :view do
+RSpec.describe 'groups/create.html.tailwindcss', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/groups/destroy.html.tailwindcss_spec.rb
+++ b/spec/views/groups/destroy.html.tailwindcss_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "groups/destroy.html.tailwindcss", type: :view do
+RSpec.describe 'groups/destroy.html.tailwindcss', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/groups/index.html.tailwindcss_spec.rb
+++ b/spec/views/groups/index.html.tailwindcss_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "groups/index.html.tailwindcss", type: :view do
+RSpec.describe 'groups/index.html.tailwindcss', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/participants/create.html.tailwindcss_spec.rb
+++ b/spec/views/participants/create.html.tailwindcss_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "participants/create.html.tailwindcss", type: :view do
+RSpec.describe 'participants/create.html.tailwindcss', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/participants/destroy.html.tailwindcss_spec.rb
+++ b/spec/views/participants/destroy.html.tailwindcss_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "participants/destroy.html.tailwindcss", type: :view do
+RSpec.describe 'participants/destroy.html.tailwindcss', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/participants/show.html.tailwindcss_spec.rb
+++ b/spec/views/participants/show.html.tailwindcss_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "participants/show.html.tailwindcss", type: :view do
+RSpec.describe 'participants/show.html.tailwindcss', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/views/participants/update.html.tailwindcss_spec.rb
+++ b/spec/views/participants/update.html.tailwindcss_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "participants/update.html.tailwindcss", type: :view do
+RSpec.describe 'participants/update.html.tailwindcss', type: :view do
   pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
Style/StringLiteralsルールを修正。
文字列展開をしていない文字列リテラルをシングルコーテーションに統一。