### PR TITLE
refactor: rubocopのLayout/IndentationWidthルールを修正。

### DIFF
--- a/app/controllers/concerns/bill_splitter.rb
+++ b/app/controllers/concerns/bill_splitter.rb
@@ -2,8 +2,9 @@ module BillSplitter
   extend ActiveSupport::Concern
   # 入力された合計金額と参加者すべてを受け取り、金額を分割する処理。
   def self.calculate_split_bill(total_amount_input, all_participants)
-    return { per_person_base_amount: 0, remainder_amount: 0, grouped_amounts: {} } 
     if all_participants.empty? || total_amount_input.nil?
+      return { per_person_base_amount: 0, remainder_amount: 0, grouped_amounts: {} }
+    end
 
     fixed_participants = all_participants.select(&:is_manual_fixed)
     unfixed_participants = all_participants.reject(&:is_manual_fixed)
@@ -38,12 +39,12 @@ module BillSplitter
     }
   end
 
-  private
-    # 手動で固定された金額を支払う参加者の合計金額を計算する
-    def self.calculate_fixed_total_sum(participants)
-      fixed_participants = participants.select(&:is_manual_fixed)
-      fixed_participants.sum { |p| p.payment_amount || 0 }
-    end
+private
+  # 手動で固定された金額を支払う参加者の合計金額を計算する
+  def self.calculate_fixed_total_sum(participants)
+    fixed_participants = participants.select(&:is_manual_fixed)
+    fixed_participants.sum { |p| p.payment_amount || 0 }
+  end
 
   # 各参加者の最終的な支払い金額を決定し、端数を分配する
   def self.assign_and_distribute_amounts(all_participants, base_amount, unfixed_participants, remainder_count)
@@ -51,16 +52,15 @@ module BillSplitter
     amounts_data = all_participants.map do |p|
       final_amount = p.is_manual_fixed ? p.payment_amount : base_amount
       { participant: p, amount: final_amount }
+      # 次に、端数を分配する
+      # if remainder_count > 0
+      #   unfixed_participants.first(remainder_count).each do |p|
+      #     item_index = amounts_data.index { |item| item[:participant] == p }
+      #     amounts_data[item_index][:amount] += 1
+      #   end
+      # end
+      amounts_data
     end
-
-    # 次に、端数を分配する
-    # if remainder_count > 0
-    #   unfixed_participants.first(remainder_count).each do |p|
-    #     item_index = amounts_data.index { |item| item[:participant] == p }
-    #     amounts_data[item_index][:amount] += 1
-    #   end
-    # end
-    amounts_data
   end
 
   # 最終的な支払い金額に基づいて参加者をグループ化
@@ -71,7 +71,7 @@ module BillSplitter
                 .to_h
   end
 
-  # 最終的な端数を算出
   def self.calculate_remainder(total_amount, calculated_total_amount)
+    # 最終的な端数を算出
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -67,21 +67,21 @@ class GroupsController < ApplicationController
   end
 
   private
-    def group_params
-      params.expect(group: [:total_amount])
-    end
+  def group_params
+    params.expect(group: [:total_amount])
+  end
 
-    def group_create_params
-      # params.expect(group: [:name, :participant_count])
-      params.expect(group: [:name])
-    end
+  def group_create_params
+    # params.expect(group: [:name, :participant_count])
+    params.expect(group: [:name])
+  end
 
-    def group_show_params
-      params.expect(group: [:id])
-    end
+  def group_show_params
+    params.expect(group: [:id])
+  end
 
-    def set_group
-      @group = Group.find(params[:id])
-    end
+  def set_group
+    @group = Group.find(params[:id])
+  end
 
 end

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -73,15 +73,15 @@ class ParticipantsController < ApplicationController
   end
 
   private
-    def set_group
-      @group = Group.find(params[:group_id])
-    end
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
 
-    def set_participant
-      @participant = @group.participants.find(params[:id])
-    end
+  def set_participant
+    @participant = @group.participants.find(params[:id])
+  end
 
-    def participant_params
-      params.require(:participant).permit(:name, :is_manual_fixed, :payment_amount)
-    end
+  def participant_params
+    params.require(:participant).permit(:name, :is_manual_fixed, :payment_amount)
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,3 +1,3 @@
 class Group < ApplicationRecord
-    has_many :participants, dependent: :destroy
+  has_many :participants, dependent: :destroy
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,3 +1,3 @@
 class Participant < ApplicationRecord
-    belongs_to :group
+  belongs_to :group
 end


### PR DESCRIPTION
インデント幅をスペース２文字に修正。