### PR TITLE
chore: rubocopのRails/I18nLocaleTextsルールを無効化。

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,3 +82,6 @@ Rails/InverseOf:
 
 Rails/EnumHash:
   Enabled: true
+
+Rails/I18nLocaleTexts:
+  Enabled: false


### PR DESCRIPTION
現時点で多言語化に対応する予定はないため、rubocopのRails/I18nLocaleTextsルールを無効化