### PR TITLE
Refactor/billspliterサービスの機能修正及びテスト修正

### DIFF
--- a/app/services/bill_splitter_service.rb
+++ b/app/services/bill_splitter_service.rb
@@ -88,12 +88,13 @@ class BillSplitterService
   end
 
   # サマリー部分を作成するメソッド
-  def calculate_summary(payment_list)
+  def calculate_summary(payment_list, unfixed_base_amount)
     total_paid = payment_list.sum { |item| item[:amount] }
     final_remainder = @total_amount - total_paid
     {
       total_amount: @total_amount,
       total_paid: total_paid,
+      unfixed_base_amount: unfixed_base_amount,
       remainder: final_remainder
     }
   end
@@ -104,7 +105,7 @@ class BillSplitterService
 
     {
       payment_rows: create_grouped_payments(payment_list),
-      summary: calculate_summary(payment_list)
+      summary: calculate_summary(payment_list, unfixed_base_amount)
     }
   end
 end

--- a/spec/services/bill_spliter_services.rb
+++ b/spec/services/bill_spliter_services.rb
@@ -19,13 +19,7 @@ RSpec.describe BillSplitterService, type: :service do
     end
 
     context '正常な割り勘の場合' do
-      it '正しく計算され、表示用の行データとサマリーが返されること' do
-        # --- 期待される結果 ---
-        # 残額: 10000 - 5000 = 5000
-        # 割り勘額: 5000 / 2人 = 2500
-        # 支払い合計: 5000 + 2500 + 2500 = 10000
-        # 端数: 10000 - 10000 = 0
-
+      it '正しく計算され、表示用の行データが返されること' do
         # payment_rowsの検証
         expect(result[:payment_rows].count).to eq 2
         # 割り勘グループの検証
@@ -34,8 +28,14 @@ RSpec.describe BillSplitterService, type: :service do
         # 固定額グループの検証
         expect(result[:payment_rows][1][:amount]).to eq 5000
         expect(result[:payment_rows][1][:participants].map(&:name)).to contain_exactly('Aさん')
+      end
 
-        # summaryの検証
+      it '正しく計算され、表示用のサマリーが返されること' do
+        # --- 期待される結果 ---
+        # 残額: 10000 - 5000 = 5000
+        # 割り勘額: 5000 / 2人 = 2500
+        # 支払い合計: 5000 + 2500 + 2500 = 10000
+        # 端数: 10000 - 10000 = 0
         expect(result[:summary][:total_amount]).to eq 10_000
         expect(result[:summary][:total_paid]).to eq 10_000
         expect(result[:summary][:remainder]).to eq 0
@@ -70,7 +70,7 @@ RSpec.describe BillSplitterService, type: :service do
           Participant.new('Cさん', false, nil) # 割り勘 (5000になるはず)
         ]
       end
-      
+
       it '同じ金額の参加者が一つの行にまとめられること' do
         # --- 期待される結果 ---
         # A: 2500, B: 5000, C: 1250, D: 1250


### PR DESCRIPTION
・テスト修正
タイポミスの修正及びコメントの削除

・billspliterサービスの変更
戻り値のハッシュ内に未固定者が支払う金額を追加。
計算結果画面で表示させる必要があるため。