### PR TITLE
chore: rubocop.ymlのタイポ修正及び設定の緩和

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,9 +55,12 @@ Layout/TrailingWhitespace:
 
 # Metrics
 Metrics/BlockLength: 
-  Enabled: false
+  Enabled: true
   Exclude:
+    - 'config/routes.rb'
     - 'spec/**/*_spec.rb'
+Metrics/MethodLength:
+  Max: 15
 
 # budler
 Bundler/OrderedGems:


### PR DESCRIPTION
・Metrics/BlockLength
無効にしていたが、テストファイル等を省いて有効化。

・Metrics/MethodLength
上限を15行に変更。短く分割すぎて逆に読みにくくなっていたため。