### PR TITLE
chore: brakemanのバージョンを更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (7.1.1)
       racc
     builder (3.3.0)
     byebug (12.0.0)


### PR DESCRIPTION
brakemanのバージョンを7.1.0→7.1.1に更新

・更新理由
ci環境のgem scan用でbrakemanを使用しており、scan時に
最新バージョンではないことによるエラーが発生していたため、
バージョンを最新に更新。